### PR TITLE
Fix snap channel in snap CI

### DIFF
--- a/.github/workflows/snap-ci.yaml
+++ b/.github/workflows/snap-ci.yaml
@@ -54,8 +54,8 @@ jobs:
           echo "Branch name: ${{ github.ref_name }}"
           echo "Event number: ${{ github.event.number }}"
           
-          if [[ "${{ github.ref_name }}" != "refs/heads/main" ]]; then
-            echo "Not on main branch"
+          if [ -n "${{ github.event.number }}" ]; then
+            echo "Triggered from a PR"
             channel="latest/edge/pr-${{ github.event.number }}"
           fi
           


### PR DESCRIPTION
Only use pr-prefix if event number is set

```
Branch name: main
Event number: 
Not on main branch
Uploading to channel: latest/edge/pr-
```

The value in `github.ref_name` is `main`, not `refs/heads/main`. This caused the action to think the build is not on the main branch and try to use the event number. But the event number is empty.

This PR reverses the logic. Always use the commit hash, unless the event number is set.