### PR TITLE
ci: use publish action from stack-utils

### DIFF
--- a/.github/workflows/snap-ci.yaml
+++ b/.github/workflows/snap-ci.yaml
@@ -45,24 +45,11 @@ jobs:
           curl -L https://huggingface.co/ggml-org/Qwen2.5-VL-7B-Instruct-GGUF/resolve/main/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf --output $GITHUB_WORKSPACE/components/model-qwen2-5-vl-7b-instruct-q4-k-m/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf
 
       - name: Build snap
-        uses: snapcore/action-build@v1
-        id: snapcraft
+        uses: canonical/action-build@v1
 
       # Requires STORE_LOGIN secret set. Export with:
       # snapcraft export-login --snaps qwen-vl --channels latest/edge/* --acls package_access,package_push,package_update,package_release --expires 2026-08-01T00:00:00Z
       - name: Publish snap
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        run: |
-          channel="latest/edge/$(git rev-parse --short HEAD)"
-          echo "Branch name: ${{ github.ref_name }}"
-          echo "Event number: ${{ github.event.number }}"
-          
-          if [ -n "${{ github.event.number }}" ]; then
-            echo "Triggered from a PR"
-            channel="latest/edge/pr-${{ github.event.number }}"
-          fi
-          
-          echo "Uploading to channel: $channel"
-
-          echo "y" | ./upload.sh $channel
+        uses: canonical/stack-utils/.github/actions/snap-publish@main
+        with:
+          store-credentials: ${{ secrets.STORE_LOGIN }}


### PR DESCRIPTION
PR depends on https://github.com/canonical/stack-utils/pull/117

- [x] Modify the commit of the action once [PR](https://github.com/canonical/stack-utils/pull/117) is merged
- [x] Confirm CI success
