### PR TITLE
Add read-all to home plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,9 @@ plugs:
     interface: content
     content: npu-libs-2404
     target: $SNAP/npu-libs
+  # To allow sideloading models by root
+  home:
+    read: all
     
 hooks:
   install:


### PR DESCRIPTION
This is to allow sideloading models from the server when run as root: as a daemon or with `sudo snap run qwen-vl server`