### PR TITLE
Update ovms and update server command

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -218,7 +218,8 @@ parts:
 
   openvino-model-server:
     plugin: dump
-    source: https://github.com/openvinotoolkit/model_server/releases/download/v2025.2.1/ovms_ubuntu24_python_on.tar.gz
+    source: https://github.com/openvinotoolkit/model_server/releases/download/v2025.3/ovms_ubuntu24_python_on.tar.gz
+    source-checksum: sha256/64e9c3f4b3bdfcd9e33e7319d17cd2a30c110bb8e33991413b6f51921cafe845
     organize:
       "*": (component/openvino-model-server)
     stage-packages:
@@ -262,7 +263,7 @@ components:
     type: standard
     summary: OpenVINO Model Server
     description: OpenVINO Model Server for serving models
-    version: v2025.2.1
+    version: v2025.3
 
   # 
   # Models

--- a/stacks/intel-gpu/server
+++ b/stacks/intel-gpu/server
@@ -62,4 +62,6 @@ $engine_component_path/bin/ovms \
     --source_model "$model_name" \
     --model_repository_path "$model_component_path" \
     --target_device "$target_device" \
-    --cache_size 2 "${extra_args[@]}"
+    --task text_generation \
+    --cache_size 2 \
+    "${extra_args[@]}"


### PR DESCRIPTION
Updating OVMS to latest version: 2025.3

The new version requires an additional argument:
```
# /snap/qwen-vl/components/x1/openvino-model-server/bin/ovms --rest_port 8080 --rest_bind_address 127.0.0.1 --source_model Qwen2.5-VL-7B-Instruct-int4-npu-ov --model_repository_path /snap/qwen-vl/components/x1/model-qwen2-5-vl-7b-instruct-ov-int4 --target_device GPU --cache_size 2 --log_level DEBUG
error parsing options - --task parameter wasn't passed
```

The [docs](https://docs.openvino.ai/2025/model-server/ovms_docs_parameters.html#pull-mode-options) list the possible values for `task`. For Qwen the appropriate value is `text_generation`.

Tested on:
- [x] Arc A580 GPU
- [x] i7-10510U CPU