### PR TITLE
chore: require at least snapd2.68 due to components support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,10 +9,8 @@ description: |
 grade: devel
 confinement: strict
 
-# According to https://snapcraft.io/docs/components
-# Components requires snapd 2.67+
 assumes:
-  - snapd2.68
+  - snapd2.68 # for components support
 
 compression: lzo
 


### PR DESCRIPTION
  https://snapcraft.io/docs/components mentions that components requires snapd 2.67+
  
  - Closes: https://github.com/canonical/inference-snaps/issues/101