### PR TITLE
Fix CI out of disk space

### DIFF
--- a/.github/workflows/snap-ci.yaml
+++ b/.github/workflows/snap-ci.yaml
@@ -1,15 +1,14 @@
 name: Snap CI
-on: [push]
 
-#on:
-#  pull_request:
-#    branches: [ main ]
-#    types:
-#      - ready_for_review
-#  push:
-#    branches: [ main ]
-#  # Allow manual trigger
-#  workflow_dispatch:
+on:
+  pull_request:
+    branches: [ main ]
+    types:
+      - ready_for_review
+  push:
+    branches: [ main ]
+  # Allow manual trigger
+  workflow_dispatch:
 
 env:
   SNAP_NAME: qwen-vl
@@ -53,8 +52,10 @@ jobs:
           curl -L https://huggingface.co/ggml-org/Qwen2.5-VL-7B-Instruct-GGUF/resolve/main/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf --output $GITHUB_WORKSPACE/components/model-qwen2-5-vl-7b-instruct-q4-k-m/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf
           # 7B model for OpenVINO on CPU or GPU
           git clone --depth 1 https://huggingface.co/helenai/Qwen2.5-VL-7B-Instruct-ov-int4 $GITHUB_WORKSPACE/components/model-qwen2-5-vl-7b-instruct-ov-int4/Qwen2.5-VL-7B-Instruct-ov-int4
+          git -C $GITHUB_WORKSPACE/components/model-qwen2-5-vl-7b-instruct-ov-int4/Qwen2.5-VL-7B-Instruct-ov-int4 lfs prune --force
           # 7B model for OpenVINO on NPU
           git clone --depth 1 https://huggingface.co/helenai/Qwen2.5-VL-7B-Instruct-ov-nf4-npu $GITHUB_WORKSPACE/components/model-qwen2-5-vl-7b-instruct-ov-nf4-npu/Qwen2.5-VL-7B-Instruct-ov-nf4-npu
+          git -C $GITHUB_WORKSPACE/components/model-qwen2-5-vl-7b-instruct-ov-nf4-npu/Qwen2.5-VL-7B-Instruct-ov-nf4-npu lfs prune --force
 
       - name: Build snap
         uses: canonical/action-build@v1
@@ -65,7 +66,3 @@ jobs:
         uses: canonical/stack-utils/.github/actions/snap-publish@main
         with:
           store-credentials: ${{ secrets.STORE_LOGIN }}
-
-      - name: Setup tmate session
-        if: always()
-        uses: canonical/action-tmate@main

--- a/components/model-qwen2-5-vl-7b-instruct-ov-int4/README.md
+++ b/components/model-qwen2-5-vl-7b-instruct-ov-int4/README.md
@@ -10,4 +10,5 @@ sudo apt install git git-lfs
 Clone:
 ```
 git clone --depth 1 https://huggingface.co/helenai/Qwen2.5-VL-7B-Instruct-ov-int4
+git -C Qwen2.5-VL-7B-Instruct-ov-int4 lfs prune --force
 ```

--- a/components/model-qwen2-5-vl-7b-instruct-ov-nf4-npu/README.md
+++ b/components/model-qwen2-5-vl-7b-instruct-ov-nf4-npu/README.md
@@ -10,4 +10,5 @@ sudo apt install git git-lfs
 Clone:
 ```
 git clone --depth 1 https://huggingface.co/helenai/Qwen2.5-VL-7B-Instruct-ov-nf4-npu
+git -C Qwen2.5-VL-7B-Instruct-ov-nf4-npu lfs prune --force
 ```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -169,11 +169,6 @@ parts:
   model-qwen2-5-vl-7b-instruct-ov-int4:
     source: components/model-qwen2-5-vl-7b-instruct-ov-int4
     plugin: dump
-    override-pull: |
-      craftctl default
-      # TODO get the component's version from git
-      # Remove .git directory as it is not required
-      rm -rf .git
     override-build: |
       # At startup OVMS (single model mode) creates the mediapipe graph file inside the model directory.
       # This directory is read-only when it is inside a component.
@@ -191,10 +186,6 @@ parts:
   model-qwen2-5-vl-7b-instruct-ov-nf4-npu:
     source: components/model-qwen2-5-vl-7b-instruct-ov-nf4-npu
     plugin: dump
-    override-pull: |
-      craftctl default
-      # TODO get the component's version from git
-      rm -rf .git
     override-build: |
       mediapipe_graph_path="Qwen2.5-VL-7B-Instruct-ov-nf4-npu/graph.pbtxt"
       if [ ! -L "$mediapipe_graph_path" ]; then


### PR DESCRIPTION
Resolves https://github.com/canonical/inference-snaps/issues/97

After some investigation it was found that the CI runner was running out of space. The runner has 100GB of storage, while our snap is in the range of ~30GB. Issue canonical/inference-snaps#97 describes this better.

This PR clones the OpenVINO models from Huggingface without history (`--depth 1`). Even when doing this, the LFS objects are both in the root of the repo, as well as cached in .git/lfs. By force pruning lfs objects, we remove the cached copy, lowering the space requirements substantially. If a developer forgets to do this step, the disk usage will be more during snapcraft pack, but the resulting snap will be the same, as .git directories do not get included by default.