### PR TITLE
Add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Build the snap and its component:
 snapcraft pack -v
 ```
 
-Refer to [dev](./dev) for additional development tools.
+Refer to the `./dev` directory for additional development tools.


### PR DESCRIPTION
The usage instructions have been moved to project documentation. Most of the content removed are outdated.