### PR TITLE
Switch to famous-models-dev/actions/publish

### DIFF
--- a/.github/workflows/snap-ci.yaml
+++ b/.github/workflows/snap-ci.yaml
@@ -68,7 +68,7 @@ jobs:
       # Requires STORE_LOGIN secret set. Export with:
       # snapcraft export-login --snaps qwen-vl --channels */edge/* --acls package_access,package_push,package_update,package_release --expires 2026-08-01T00:00:00Z <file>
       - name: Publish snap
-        uses: canonical/famous-models-dev/actions/publish@action-custom-track
+        uses: canonical/famous-models-dev/actions/publish@main
         with:
           store-credentials: ${{ secrets.STORE_LOGIN }}
           snap-track: "2.5"


### PR DESCRIPTION
Replace deprecated action from stack-utils with famous-models-dev/actions/publish