### PR TITLE
Change build workflow to trigger with a label

### DIFF
--- a/.github/workflows/snap-ci.yaml
+++ b/.github/workflows/snap-ci.yaml
@@ -39,6 +39,7 @@ jobs:
 
   build:
     name: Build and publish snap
+    needs: [trigger]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This improves a few things:

- Loosens the trigger to PRs against all branches, but taking the workflow from the default branch (pull_request_target) for security purposes.
- It allows triggering the build workflow by settings the `needs-build` label. 
- It restricts access to triggering a build to those who have access to manage labels. For contributor PRs, the maintainer can add the label when a build is required.
- On trigger, a comment is added, linking to the workflow run and commit, this makes it easier to find the workflow, but adds a lot of noise if the snap is rebuilt several times.
- The label is removed after the build, in a way informing that it was completed.