### PR TITLE
ci: Fix code checkout's reference

### DIFF
--- a/.github/workflows/snap-ci.yaml
+++ b/.github/workflows/snap-ci.yaml
@@ -1,6 +1,8 @@
 name: Snap CI
 
 on:
+  # Use pull_request_target to grant write access to the PR
+  # This event runs from the context of the base of the PR rather than its head, affecting the default checkout behavior
   pull_request_target:
     types: [ labeled ]
   
@@ -65,6 +67,8 @@ jobs:
           lfs: true
           submodules: true
           token: ${{ secrets.SUBMODULE_PAT }}
+          # When triggered by pull_request_target, checkout PR's HEAD (rather than base), otherwise use github.sha
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Download models
         run: |


### PR DESCRIPTION
The trigger event for PRs was changed from `pull_request` to `pull_request_target` in #56 to grant the workflow's token permission for commenting and removing the label. The side effect of that is that the workflow runs from the context of the base of the PR (the base branch), checking out code from the head of the main branch.

This PR changes the checkout reference so that it checks out the code from the head of the PR's branch. With this, we need to treat community PRs with care before allowing a workflow to run.