### PR TITLE
Update publish action repo in snap-ci.yaml

### DIFF
--- a/.github/workflows/snap-ci.yaml
+++ b/.github/workflows/snap-ci.yaml
@@ -96,7 +96,7 @@ jobs:
       # Requires STORE_LOGIN secret set. Export with:
       # snapcraft export-login --snaps qwen-vl --channels */edge/* --acls package_access,package_push,package_update,package_release --expires 2026-08-01T00:00:00Z <file>
       - name: Publish snap
-        uses: canonical/famous-models-dev/actions/publish@main
+        uses: canonical/inference-snaps-dev/actions/publish@main
         with:
           store-credentials: ${{ secrets.STORE_LOGIN }}
           snap-track: "2.5"


### PR DESCRIPTION
The action repo was renamed recently: https://github.com/canonical/inference-snaps-dev/pull/12