### PR TITLE
Also allow manual triggering snap-ci

### DIFF
--- a/.github/workflows/snap-ci.yaml
+++ b/.github/workflows/snap-ci.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   trigger:
     name: Comment and trigger build
-    if: github.event_name == 'push' || 
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'needs-build') 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Allow workflow to run when manually triggered.

Before this change: https://github.com/canonical/qwen-vl-snap/actions/runs/18525881070

After this change: https://github.com/canonical/qwen-vl-snap/actions/runs/18526241938