### PR TITLE
Disable waiting before chat

### DIFF
--- a/apps/chat.sh
+++ b/apps/chat.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -eu
 
-$SNAP/bin/wait-for-server.sh
-
 port="$(qwen-vl get http.port)"
 model_name="$(qwen-vl get model-name 2>/dev/null || true)" # model name isn't always set
 


### PR DESCRIPTION
When calling chat after changing HTTP configurations but not restarting the server, the chat command waits for the server, even though this isn't going to have a positive result:
```console
$ qwen-vl chat
Connected to http://localhost:8326/v3
Type your prompt, then ENTER to submit. CTRL-C to quit.
» ^C
Closing chat

$ sudo qwen-vl set http.port=9999

$ qwen-vl chat
Waiting for server .......................................................................................................
Timed out waiting for server to start. Check the server logs and try again.
Error: error running chat command: exit status 1
```

The error message, after a long wait, is printed prior to the execution of the chat app. The error message doesn’t help the user to diagnose the issue, that is: server not listening on this port. The error message is actually misleading, the server is already running.

This PR removes the use of the wait script. The responses aren't great, but better than before. The "Mediapipe" error is from the server, giving a not very helpful response to a completion request. The messages that come afterward help debug that issue.
```console
$ qwen-vl status
engine: intel-gpu
status: starting
endpoints:
    openai: http://localhost:8326/v3

$ qwen-vl chat
POST "http://localhost:8326/v3/chat/completions": 404 Not Found "Mediapipe graph definition with requested name is not found"

Unable to chat. Make sure the server has started successfully.
Error: error running chat command: exit status 1

$ qwen-vl chat
Connected to http://localhost:8326/v3
Type your prompt, then ENTER to submit. CTRL-C to quit.
» ^C
Closing chat

$ sudo qwen-vl set http.port=9999

$ qwen-vl chat
Post "http://localhost:9999/v3/chat/completions": dial tcp 127.0.0.1:9999: connect: connection refused

Unable to chat. Make sure the server has started successfully.
Error: error running chat command: exit status 1
```
