### PR TITLE
Add kernel-module-observe interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,6 +52,7 @@ hooks:
     plugs:
       # For hardware detection
       - hardware-observe
+      - kernel-module-observe
       - opengl
 
 parts:
@@ -390,8 +391,9 @@ apps:
     completer: bin/completion.bash
     plugs:
       # For hardware detection
-      - opengl
       - hardware-observe
+      - kernel-module-observe
+      - opengl
       # To access server over network socket
       - network
     environment:


### PR DESCRIPTION
Related:
* Resolves https://github.com/canonical/inference-snaps/issues/148
* Related to https://github.com/canonical/deepseek-r1-snap/pull/161

`clinfo` requires access to the kernel modules on a machine with NVIDIA GPU. Without it this application hangs indefinitely. The [interface](https://snapcraft.io/docs/kernel-module-observe-interface) does not auto connect, but also does not seem privileged.