### PR TITLE
Update llama.cpp to b8157 and OpenVINO Model Server to v2026.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -364,7 +364,7 @@ components:
     type: standard
     summary: OpenVINO Model Server
     description: OpenVINO Model Server for serving models
-    version: v2025.3
+    version: v2026.0
 
   # 
   # Models

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -273,8 +273,8 @@ parts:
 
   openvino-model-server:
     plugin: dump
-    source: https://github.com/openvinotoolkit/model_server/releases/download/v2025.3/ovms_ubuntu24_python_on.tar.gz
-    source-checksum: sha256/64e9c3f4b3bdfcd9e33e7319d17cd2a30c110bb8e33991413b6f51921cafe845
+    source: https://github.com/openvinotoolkit/model_server/releases/download/v2026.0/ovms_ubuntu24_python_on.tar.gz
+    source-checksum: sha256/264a58794e9ead355156ebf55f43e19e6de71bab07b5b19fa9c23e4ee83d9faf
     organize:
       "*": (component/openvino-model-server)
     stage-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,11 +99,10 @@ parts:
 
   llamacpp: &llamacpp-part
     source: https://github.com/ggerganov/llama.cpp.git
-    source-tag: &llamacpp-tag b5794
+    source-tag: &llamacpp-tag b8157
     source-depth: 1
     plugin: cmake
     cmake-parameters:
-      - -DLLAMA_CURL=OFF
       - -DGGML_NATIVE=OFF
     stage-packages:
       - libgomp1
@@ -114,7 +113,6 @@ parts:
   llamacpp-avx512:
     <<: *llamacpp-part
     cmake-parameters:
-      - -DLLAMA_CURL=OFF
       - -DGGML_NATIVE=OFF
       - -DGGML_AVX512=ON
     organize:
@@ -131,7 +129,6 @@ parts:
       - libcudart12
       - libcublas12
     cmake-parameters:
-      - -DLLAMA_CURL=OFF
       - -DGGML_NATIVE=OFF
       - -DGGML_CUDA=ON
       - -DCMAKE_CUDA_ARCHITECTURES=all-major


### PR DESCRIPTION
This PR updates _llama.cpp_ to version `b8157`, and _OpenVINO model server_ to version `v2026.0`