### PR TITLE
Add testing workflow to repo

### DIFF
--- a/.github/workflows/build-and-test-pr.yaml
+++ b/.github/workflows/build-and-test-pr.yaml
@@ -1,0 +1,61 @@
+name: Build+Test PR
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  remove-build-label:
+    uses: canonical/inference-snaps-dev/.github/workflows/remove-label.yaml@v2
+    with:
+      label: ${{ vars.PR_BUILD_TRIGGER_LABEL }}
+  
+  remove-test-label:
+    uses: canonical/inference-snaps-dev/.github/workflows/remove-label.yaml@v2
+    with:
+      label: ${{ vars.PR_TEST_TRIGGER_LABEL }}
+
+  build-pre-check:
+    if: ${{ github.event.label.name == vars.PR_TEST_TRIGGER_LABEL }}
+    runs-on: ubuntu-latest
+    outputs:
+      build-success: ${{ steps.build-pre-check.outputs.build-success }}
+    steps:
+      - id: build-pre-check
+        name: Check for existing successful build
+        uses: canonical/inference-snaps-testing/.github/actions/build-pre-check@IENG-2278-testing-workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          workflow-name: ${{ github.workflow }}
+  build-and-publish:
+    # This dependency ensures that build-and-publish runs after build-pre-check finishes.
+    needs: [build-pre-check]
+    # Normally, build-and-publish would be skipped if build-pre-check is skipped because it depends on it.
+    # always() is added so build-and-publish still runs when build-pre-check is skipped,
+    # for example when PR_BUILD_TRIGGER_LABEL is added.
+    if: always() && ((github.event.label.name == vars.PR_BUILD_TRIGGER_LABEL) || (github.event.label.name == vars.PR_TEST_TRIGGER_LABEL && needs.build-pre-check.outputs.build-success == 'false'))
+    uses: canonical/inference-snaps-dev/.github/workflows/build-publish-snap.yaml@v2
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - [ self-hosted, amd64, noble, large ]
+          - [ self-hosted, arm64, noble, large ]
+    with:
+      runner: "${{ toJSON(matrix.runner) }}"
+      init-build-script: 'prepare-models.sh'
+      # Publish to a channel with the pr number in it
+      publish-channel: latest/edge/pr-${{ github.event.pull_request.number }} # Add track if needed, e.g., 24/latest/edge/pr-#
+    secrets:
+      store-credentials: ${{ secrets.STORE_LOGIN }}
+  
+  test:
+    # This dependency ensures that test runs after build-and-publish finishes.
+    needs: [build-and-publish]
+    # always() is added so test still runs when build-and-publish is skipped, for example when build-pre-check finds an existing successful build and skips build-and-publish.
+    if: ${{ always() && github.event.label.name == vars.PR_TEST_TRIGGER_LABEL && (needs.build-and-publish.result == 'success' || needs.build-and-publish.result == 'skipped') }}
+    uses: ./.github/workflows/testflinger-tests.yaml
+    with:
+      snap-channel: latest/edge/pr-${{ github.event.pull_request.number }}
+

--- a/.github/workflows/testflinger-tests.yaml
+++ b/.github/workflows/testflinger-tests.yaml
@@ -1,81 +1,99 @@
-name: Testflinger tests
+name: Testflinger Tests
 
 on:
-  # Manual trigger
+  workflow_call:
+    inputs:
+      snap-channel:
+        description: Snap channel to test
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
-      channel:
-        description: 'Snap store channel'
+      snap-channel:
+        description: Snap channel to test
         required: true
         type: string
 
 jobs:
-  test:
-    name: Test
+  test-multimodal-prompt:
+    name: qwen-vl ${{ matrix.jobs.select-engine }}
     strategy:
-      # max-parallel: Don't use this as the self-hosted Github runners team wants to see and fix scaling issues.
-      # These limits also do not apply to dynamic instances, like the standard self-hosted runners.
       fail-fast: false
       matrix:
         jobs:
-          - job_queue: ampere-altra
-            expected_engine: ampere-altra
-            expected_tps: 9
-          - job_queue: ampere-altra-max
-            expected_engine: ampere-altra
-            expected_tps: 18
-          - job_queue: ampere-one
-            expected_engine: ampere-one
-            expected_tps: 9
-          - job_queue: docker-nvidia
-            expected_engine: cuda
-            expected_tps: 10
-            install_nvidia_drivers: true
-            nvidia_drivers_version: 550
-            select_engine: cuda
+          - job-queue: maas-systemtests-amd64
+            provision-data: "distro: noble"
+            select-engine: cpu
+            test-chat-tps: true
+            test-image-prompt: true
 
-    runs-on: self-hosted-linux-amd64-jammy-private-endpoint-medium
+          - job-queue: 202409-35502
+            provision-data: "distro: noble"
+            select-engine: cpu-avx512
+            test-chat-tps: true
+            test-image-prompt: true
 
-    env:
-      TEST_DIR: dev/tests/testflinger
+          - job-queue: mir-intel-noble
+            provision-data: "distro: noble"
+            select-engine: intel-cpu
+            test-chat-tps: true
+            test-image-prompt: true
 
-    steps:
-      - name: Show configuration
-        run: |
-          echo ::notice::Channel: ${{ inputs.channel }}, \
-          Queue: ${{ matrix.jobs.job_queue }}, \
-          Engine: ${{ matrix.jobs.expected_engine }}, \
-          TPS: ${{ matrix.jobs.expected_tps }}
+          - job-queue: 202111-29603 # Alder Lake, GPU 8086:4680
+            provision-data: "distro: noble"
+            select-engine: intel-gpu
+            test-chat-tps: true
+            test-image-prompt: true
 
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          submodules: true
-          token: ${{ secrets.SUBMODULE_PAT }}
+          - job-queue: hp-prodesk-4-sff-g1i-desktop-ai-pc-ag8j7av-c36704
+            provision-data: "url: https://tel-image-cache.canonical.com/oem-share/sutton/releases/noble/oem-24.04c/20251009-80/sutton-noble-oem-24.04c-20251009-80.iso"
+            install-intel-npu-driver: true
+            select-engine: intel-npu
+            test-chat-tps: false # npu engine does not work with text only input
+            test-image-prompt: true
 
-      - name: Add config to testflinger job
-        env:
-          SNAP_NAME: qwen-vl
-          SNAP_CHANNEL: ${{ inputs.channel }}
-          JOB_QUEUE: ${{ matrix.jobs.job_queue }}
-          EXPECTED_ENGINE: ${{ matrix.jobs.expected_engine }}
-          EXPECTED_TPS: ${{ matrix.jobs.expected_tps }}
-          INSTALL_NVIDIA_DRIVERS: ${{ matrix.jobs.install_nvidia_drivers }}
-          NVIDIA_DRIVERS_VERSION: ${{ matrix.jobs.nvidia_drivers_version }}
-          SELECT_ENGINE: ${{ matrix.jobs.select_engine }}
+          - job-queue: anbox-nvidia-amd64
+            provision-data: "distro: noble"
+            install-nvidia-driver-version: 550
+            select-engine: cuda
+            test-chat-tps: true
+            test-image-prompt: true
 
-        run: |
-          envsubst \
-            < $TEST_DIR/testflinger.yaml \
-            > $TEST_DIR/testflinger.temp.yaml
-          mv $TEST_DIR/testflinger.temp.yaml $TEST_DIR/testflinger.yaml
+          - job-queue: ampere-altra
+            provision-data: "distro: noble"
+            select-engine: ampere-altra
+            test-chat-tps: true
+            test-image-prompt: true
 
-      - name: Print testflinger job
-        run: |
-          cat ${{ env.TEST_DIR }}/testflinger.yaml
+          - job-queue: ampere-one
+            provision-data: "distro: noble"
+            select-engine: ampere-one
+            test-chat-tps: true
+            test-image-prompt: true
 
-      - name: Run testflinger job
-        uses: canonical/testflinger/.github/actions/submit@main
-        with:
-          poll: true
-          job-path: ${{ env.TEST_DIR }}/testflinger.yaml
+          - job-queue: maas-systemtests-amd64
+            provision-data: "distro: noble"
+            select-engine: cpu-tiny
+            test-chat-tps: true
+            test-image-prompt: false # cpu-tiny does not support image input
+
+    uses: canonical/inference-snaps-testing/.github/workflows/test-snap.yaml@v1
+    secrets: inherit
+    with:
+      job-queue: ${{ matrix.jobs.job-queue }}
+      provision-data: ${{ matrix.jobs.provision-data }}
+
+      snap-name: qwen-vl
+      snap-channel: ${{ inputs.snap-channel }}
+
+      install-nvidia-driver-version: ${{ matrix.jobs.install-nvidia-driver-version }}
+      install-intel-npu-driver: ${{ matrix.jobs.install-intel-npu-driver == true }}
+      snap-connections: ${{ matrix.jobs.snap-connections }}
+
+      expected-engine: ${{ matrix.jobs.expected-engine }}
+      select-engine: ${{ matrix.jobs.select-engine }}
+
+      test-chat-tps: ${{ matrix.jobs.test-chat-tps == true }}
+      expected-tps: ${{ matrix.jobs.expected-tps }}
+
+      test-image-prompt: ${{ matrix.jobs.test-image-prompt == true }}


### PR DESCRIPTION
This PR follows development done for gemma3 snap in https://github.com/canonical/gemma3-snap/pull/100.

The label trigger-build will trigger a workflow that builds and publishes the snap.
The label trigger-tests will trigger a workflow that checks if a build is present on the last commit and start testflinger tests. If build is not present a build and publish will also be triggered.

This PR needs https://github.com/canonical/inference-snaps-testing/pull/22