### PR TITLE
Update dependency canonical/inference-snaps-cli to v2.0.0-beta.9 and refactor model IDs

### DIFF
--- a/engines/ampere-altra/engine.yaml
+++ b/engines/ampere-altra/engine.yaml
@@ -15,9 +15,9 @@ devices:
 runtime: llama-aio
 
 model:
-  default: qwen2-5-vl-3b-aio-q8r16-gguf
+  default: qwen2.5-vl-3b-aio
   options:
-    - qwen2-5-vl-3b-aio-q8r16-gguf
+    - qwen2.5-vl-3b-aio
 
 configurations:
   sleep-idle-seconds: 600

--- a/engines/ampere-one/engine.yaml
+++ b/engines/ampere-one/engine.yaml
@@ -16,9 +16,9 @@ devices:
 runtime: llama-aio-ampereone
 
 model:
-  default: qwen2-5-vl-3b-aio-q8r16-gguf
+  default: qwen2.5-vl-3b-aio
   options:
-    - qwen2-5-vl-3b-aio-q8r16-gguf
+    - qwen2.5-vl-3b-aio
 
 configurations:
   sleep-idle-seconds: 600

--- a/engines/cpu/engine.yaml
+++ b/engines/cpu/engine.yaml
@@ -16,10 +16,10 @@ devices:
 runtime: llamacpp
 
 model:
-  default: qwen2-5-vl-7b-q4-k-m-gguf
+  default: qwen2.5-vl-7b
   options:
-    - qwen2-5-vl-7b-q4-k-m-gguf
-    - qwen2-5-vl-3b-q4-k-m-gguf
+    - qwen2.5-vl-7b
+    - qwen2.5-vl-3b
 
 configurations:
   sleep-idle-seconds: 600

--- a/engines/intel-cpu/engine.yaml
+++ b/engines/intel-cpu/engine.yaml
@@ -14,9 +14,9 @@ devices:
 runtime: openvino-model-server
 
 model:
-  default: qwen2-5-vl-3b-ov-int4
+  default: qwen2.5-vl-3b-ov
   options:
-    - qwen2-5-vl-3b-ov-int4
+    - qwen2.5-vl-3b-ov
 
 configurations:
   sleep-idle-seconds: 600

--- a/engines/intel-gpu/engine.yaml
+++ b/engines/intel-gpu/engine.yaml
@@ -369,6 +369,6 @@ devices:
 runtime: openvino-model-server
 
 model:
-  default: qwen2-5-vl-3b-ov-int4
+  default: qwen2.5-vl-3b-ov
   options:
-    - qwen2-5-vl-3b-ov-int4
+    - qwen2.5-vl-3b-ov

--- a/engines/intel-npu/engine.yaml
+++ b/engines/intel-npu/engine.yaml
@@ -22,9 +22,9 @@ devices:
 runtime: openvino-model-server
 
 model:
-  default: qwen2-5-vl-3b-ov-int4-npu
+  default: qwen2.5-vl-3b-ov-npu
   options:
-    - qwen2-5-vl-3b-ov-int4-npu
+    - qwen2.5-vl-3b-ov-npu
 
 configurations:
   sleep-idle-seconds: 600

--- a/engines/nvidia-gpu/engine.yaml
+++ b/engines/nvidia-gpu/engine.yaml
@@ -21,10 +21,10 @@ devices:
 runtime: llamacpp-cuda
 
 model:
-  default: qwen2-5-vl-7b-q4-k-m-gguf
+  default: qwen2.5-vl-7b
   options:
-    - qwen2-5-vl-7b-q4-k-m-gguf
-    - qwen2-5-vl-3b-q4-k-m-gguf
+    - qwen2.5-vl-7b
+    - qwen2.5-vl-3b
 
 configurations:
   sleep-idle-seconds: 600

--- a/models/qwen2.5-vl-3b-aio/model.yaml
+++ b/models/qwen2.5-vl-3b-aio/model.yaml
@@ -1,6 +1,6 @@
-id: qwen2-5-vl-3b-aio-q8r16-gguf
-name: 3b-aio
-quantization: Q8R16
+name: qwen2.5-vl-3b-aio
+alias: qwen2.5-vl-3b
+quantization: q8r16
 disk-size: 3800M
 
 description: |

--- a/models/qwen2.5-vl-3b-ov-npu/model.yaml
+++ b/models/qwen2.5-vl-3b-ov-npu/model.yaml
@@ -1,6 +1,6 @@
-id: qwen2-5-vl-3b-ov-int4-npu
-name: 3b-ov-int4-npu
-quantization: INT4
+name: qwen2.5-vl-3b-ov-npu
+alias: qwen2.5-vl-3b
+quantization: int4
 disk-size: 2600M
 
 description: |

--- a/models/qwen2.5-vl-3b-ov/model.yaml
+++ b/models/qwen2.5-vl-3b-ov/model.yaml
@@ -1,6 +1,6 @@
-id: qwen2-5-vl-3b-ov-int4
-name: 3b-ov-int4
-quantization: INT4
+name: qwen2.5-vl-3b-ov
+alias: qwen2.5-vl-3b
+quantization: int4
 disk-size: 2640M
 
 description: |

--- a/models/qwen2.5-vl-3b/model.yaml
+++ b/models/qwen2.5-vl-3b/model.yaml
@@ -1,6 +1,5 @@
-id: qwen2-5-vl-3b-q4-k-m-gguf
-name: 3b
-quantization: Q4_K_M
+name: qwen2.5-vl-3b
+quantization: q4-k-m
 disk-size: 2650M
 
 description: |

--- a/models/qwen2.5-vl-7b/model.yaml
+++ b/models/qwen2.5-vl-7b/model.yaml
@@ -1,6 +1,5 @@
-id: qwen2-5-vl-7b-q4-k-m-gguf
-name: 7b
-quantization: Q4_K_M
+name: qwen2.5-vl-7b
+quantization: q4-k-m
 disk-size: 5290M
 
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,8 +113,8 @@ parts:
 
   cli:
     source:
-      - on amd64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.8/inference-snaps-cli-linux-amd64.tar.xz
-      - on arm64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.8/inference-snaps-cli-linux-arm64.tar.xz
+      - on amd64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.9/inference-snaps-cli-linux-amd64.tar.xz
+      - on arm64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.9/inference-snaps-cli-linux-arm64.tar.xz
     plugin: dump
     override-build: |
       # For tab completion


### PR DESCRIPTION
Updates the inference-snaps-cli dependency from v2.0.0-beta.8 to v2.0.0-beta.9 and refactors the model identifiers to match the new CLI schema (the \`id\` field was removed, \`name\` is now the primary key and must match the model's directory name).
## Model ID refactor
| Old directory / id | New \`name\` | \`alias\` | \`quantization\` |
|--------------------|------------|---------|----------------|
| \`qwen2-5-vl-3b-q4-k-m-gguf\` | \`qwen2.5-vl-3b\` | — | \`q4-k-m\` |
| \`qwen2-5-vl-7b-q4-k-m-gguf\` | \`qwen2.5-vl-7b\` | — | \`q4-k-m\` |
| \`qwen2-5-vl-3b-ov-int4\` | \`qwen2.5-vl-3b-ov\` | \`qwen2.5-vl-3b\` | \`int4\` |
| \`qwen2-5-vl-3b-ov-int4-npu\` | \`qwen2.5-vl-3b-ov-npu\` | \`qwen2.5-vl-3b\` | \`int4\` |
| \`qwen2-5-vl-3b-aio-q8r16-gguf\` | \`qwen2.5-vl-3b-aio\` | \`qwen2.5-vl-3b\` | \`q8r16\` |
- Names use the \`qwen2.5-vl-\` prefix (dot kept per naming rules) plus the parameter count.
- llama.cpp/GGUF variants keep the short names; OpenVINO and AIO variants get suffixes (\`-ov\`, \`-ov-npu\`, \`-aio\`) and alias back to the short GGUF name.
- Model directories renamed to match the new names; all 7 engine.yaml files updated.