### PR TITLE
Revert model quantization field changes from beta.9 refactor

### DIFF
--- a/models/qwen2.5-vl-3b-aio/model.yaml
+++ b/models/qwen2.5-vl-3b-aio/model.yaml
@@ -1,6 +1,6 @@
 name: qwen2.5-vl-3b-aio
 alias: qwen2.5-vl-3b
-quantization: q8r16
+quantization: Q8R16
 disk-size: 3800M
 
 description: |

--- a/models/qwen2.5-vl-3b-ov-npu/model.yaml
+++ b/models/qwen2.5-vl-3b-ov-npu/model.yaml
@@ -1,6 +1,6 @@
 name: qwen2.5-vl-3b-ov-npu
 alias: qwen2.5-vl-3b
-quantization: int4
+quantization: INT4
 disk-size: 2600M
 
 description: |

--- a/models/qwen2.5-vl-3b-ov/model.yaml
+++ b/models/qwen2.5-vl-3b-ov/model.yaml
@@ -1,6 +1,6 @@
 name: qwen2.5-vl-3b-ov
 alias: qwen2.5-vl-3b
-quantization: int4
+quantization: INT4
 disk-size: 2640M
 
 description: |

--- a/models/qwen2.5-vl-3b/model.yaml
+++ b/models/qwen2.5-vl-3b/model.yaml
@@ -1,5 +1,5 @@
 name: qwen2.5-vl-3b
-quantization: q4-k-m
+quantization: Q4_K_M
 disk-size: 2650M
 
 description: |

--- a/models/qwen2.5-vl-7b/model.yaml
+++ b/models/qwen2.5-vl-7b/model.yaml
@@ -1,5 +1,5 @@
 name: qwen2.5-vl-7b
-quantization: q4-k-m
+quantization: Q4_K_M
 disk-size: 5290M
 
 description: |


### PR DESCRIPTION
This PR reverts changes made to the model `quantization` fields in `model.yaml` files, which were introduced by [Update dependency canonical/inference-snaps-cli to v2.0.0-beta.9 and refactor model IDs](https://github.com/canonical/qwen-vl-snap/pull/125).